### PR TITLE
Delete sik.md

### DIFF
--- a/_staff_members/sik.md
+++ b/_staff_members/sik.md
@@ -1,7 +1,0 @@
----
-name: Joan Massich
-position: Research engineer
-website: https://massich.cat
-image_path: /images/joan.jpeg
-blurb: Research engineer at CNRS, MNE-Python core-developer.
----


### PR DESCRIPTION
this is a duplication in sik's profile tile on the website. one is blank and is fixed for Joan and the second one removed because it is a dupe and throws off the ordering (filename doesn't match first name). maybe we should document best practices next time lol